### PR TITLE
테스트 상태 관리 구현

### DIFF
--- a/src/app/test/question/1/page.tsx
+++ b/src/app/test/question/1/page.tsx
@@ -1,20 +1,19 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import { Header } from "@/design-system/components/Header/Header";
 import { Title } from "@/design-system/components/Title";
 import { LabelButton } from "@/design-system/components/LabelButton";
 import { InputFieldGroup } from "@/design-system/components/InputFieldGroup";
 import { CTAButtonGroup } from "@/design-system/components/CTAButtonGroup";
 import { colors } from "@/design-system/foundations/colors";
+import { useTestStore } from "@/store/useTestStore";
 
 export default function Question1() {
   const router = useRouter();
-  const [gender, setGender] = useState("");
-  const [name, setName] = useState("");
+  const { userInfo, setUserInfo } = useTestStore();
 
-  const isFormValid = gender && name;
+  const isFormValid = userInfo.gender && userInfo.name;
 
   const handleNext = () => {
     if (isFormValid) {
@@ -87,8 +86,8 @@ export default function Question1() {
             { label: '남성', value: 'male' },
             { label: '여성', value: 'female' },
           ]}
-          selectedValue={gender}
-          onSelect={setGender}
+          selectedValue={userInfo.gender}
+          onSelect={(value) => setUserInfo({ gender: value })}
         />
 
         {/* 이름 입력 */}
@@ -97,9 +96,9 @@ export default function Question1() {
           size="md"
           label="내 이름"
           items={[
-            { key: 'name', value: name, placeholder: '홍길동' },
+            { key: 'name', value: userInfo.name, placeholder: '홍길동' },
           ]}
-          onChange={(_, value) => setName(value)}
+          onChange={(_, value) => setUserInfo({ name: value })}
         />
       </div>
 

--- a/src/app/test/question/2/page.tsx
+++ b/src/app/test/question/2/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import { Header } from "@/design-system/components/Header/Header";
 import { Title } from "@/design-system/components/Title";
 import { InputFieldGroup } from "@/design-system/components/InputFieldGroup";
@@ -9,16 +8,13 @@ import { InputField } from "@/design-system/components/InputField";
 import { LabelButton } from "@/design-system/components/LabelButton";
 import { CTAButtonGroup } from "@/design-system/components/CTAButtonGroup";
 import { colors } from "@/design-system/foundations/colors";
+import { useTestStore } from "@/store/useTestStore";
 
 export default function Question2() {
   const router = useRouter();
-  const [year, setYear] = useState("");
-  const [month, setMonth] = useState("");
-  const [day, setDay] = useState("");
-  const [unknownTime, setUnknownTime] = useState(false);
-  const [birthTime, setBirthTime] = useState("");
+  const { userBirth, setUserBirth } = useTestStore();
 
-  const isFormValid = year && month && day && (unknownTime || birthTime);
+  const isFormValid = userBirth.year && userBirth.month && userBirth.day && (userBirth.unknownTime || userBirth.birthTime);
 
   const handleNext = () => {
     if (isFormValid) {
@@ -88,14 +84,14 @@ export default function Question2() {
           size="md"
           label="생년월일"
           items={[
-            { key: 'year', value: year, placeholder: '2000', suffix: '년', type: 'number', maxLength: 4 },
-            { key: 'month', value: month, placeholder: '1', suffix: '월', type: 'number', maxLength: 2 },
-            { key: 'day', value: day, placeholder: '1', suffix: '일', type: 'number', maxLength: 2 },
+            { key: 'year', value: userBirth.year, placeholder: '2000', suffix: '년', type: 'number', maxLength: 4 },
+            { key: 'month', value: userBirth.month, placeholder: '1', suffix: '월', type: 'number', maxLength: 2 },
+            { key: 'day', value: userBirth.day, placeholder: '1', suffix: '일', type: 'number', maxLength: 2 },
           ]}
           onChange={(key, value) => {
-            if (key === 'year') setYear(value);
-            else if (key === 'month') setMonth(value);
-            else if (key === 'day') setDay(value);
+            if (key === 'year') setUserBirth({ year: value });
+            else if (key === 'month') setUserBirth({ month: value });
+            else if (key === 'day') setUserBirth({ day: value });
           }}
         />
 
@@ -105,18 +101,18 @@ export default function Question2() {
           size="sm"
           label="태어난 시간"
           checkLabel="잘 모르겠어요"
-          checked={unknownTime}
-          onCheck={setUnknownTime}
+          checked={userBirth.unknownTime}
+          onCheck={(checked) => setUserBirth({ unknownTime: checked })}
         />
 
         {/* 시간 입력 */}
         <div style={{ padding: '0 20px 20px' }}>
           <InputField
             type="text"
-            value={birthTime}
-            onChange={setBirthTime}
+            value={userBirth.birthTime}
+            onChange={(value) => setUserBirth({ birthTime: value })}
             placeholder="00 : 00"
-            disabled={unknownTime}
+            disabled={userBirth.unknownTime}
           />
         </div>
       </div>

--- a/src/app/test/question/3/page.tsx
+++ b/src/app/test/question/3/page.tsx
@@ -1,20 +1,19 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import { Header } from "@/design-system/components/Header/Header";
 import { Title } from "@/design-system/components/Title";
 import { LabelButton } from "@/design-system/components/LabelButton";
 import { InputFieldGroup } from "@/design-system/components/InputFieldGroup";
 import { CTAButtonGroup } from "@/design-system/components/CTAButtonGroup";
 import { colors } from "@/design-system/foundations/colors";
+import { useTestStore } from "@/store/useTestStore";
 
 export default function Question3() {
   const router = useRouter();
-  const [gender, setGender] = useState("");
-  const [name, setName] = useState("");
+  const { partnerInfo, setPartnerInfo } = useTestStore();
 
-  const isFormValid = gender && name;
+  const isFormValid = partnerInfo.gender && partnerInfo.name;
 
   const handleNext = () => {
     if (isFormValid) {
@@ -87,8 +86,8 @@ export default function Question3() {
             { label: '남성', value: 'male' },
             { label: '여성', value: 'female' },
           ]}
-          selectedValue={gender}
-          onSelect={setGender}
+          selectedValue={partnerInfo.gender}
+          onSelect={(value) => setPartnerInfo({ gender: value })}
         />
 
         {/* 이름 입력 */}
@@ -97,9 +96,9 @@ export default function Question3() {
           size="md"
           label="그녀의 이름"
           items={[
-            { key: 'name', value: name, placeholder: '홍길동' },
+            { key: 'name', value: partnerInfo.name, placeholder: '홍길동' },
           ]}
-          onChange={(_, value) => setName(value)}
+          onChange={(_, value) => setPartnerInfo({ name: value })}
         />
       </div>
 

--- a/src/app/test/question/4/page.tsx
+++ b/src/app/test/question/4/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import { Header } from "@/design-system/components/Header/Header";
 import { Title } from "@/design-system/components/Title";
 import { InputFieldGroup } from "@/design-system/components/InputFieldGroup";
@@ -9,19 +8,13 @@ import { InputField } from "@/design-system/components/InputField";
 import { LabelButton } from "@/design-system/components/LabelButton";
 import { CTAButtonGroup } from "@/design-system/components/CTAButtonGroup";
 import { colors } from "@/design-system/foundations/colors";
+import { useTestStore } from "@/store/useTestStore";
 
 export default function Question4() {
   const router = useRouter();
-  const [year, setYear] = useState("");
-  const [month, setMonth] = useState("");
-  const [day, setDay] = useState("");
-  const [unknownTime, setUnknownTime] = useState(false);
-  const [birthTime, setBirthTime] = useState("");
-  const [hairColor, setHairColor] = useState("");
-  const [eyeColor, setEyeColor] = useState("");
-  const [skinColor, setSkinColor] = useState("");
+  const { partnerBirth, setPartnerBirth } = useTestStore();
 
-  const isFormValid = year && month && day && (unknownTime || birthTime) && hairColor && eyeColor && skinColor;
+  const isFormValid = partnerBirth.year && partnerBirth.month && partnerBirth.day && (partnerBirth.unknownTime || partnerBirth.birthTime) && partnerBirth.hairColor && partnerBirth.eyeColor && partnerBirth.skinColor;
 
   const handleNext = () => {
     if (isFormValid) {
@@ -91,14 +84,14 @@ export default function Question4() {
           size="md"
           label="생년월일"
           items={[
-            { key: 'year', value: year, placeholder: '2000', suffix: '년', type: 'number', maxLength: 4 },
-            { key: 'month', value: month, placeholder: '1', suffix: '월', type: 'number', maxLength: 2 },
-            { key: 'day', value: day, placeholder: '1', suffix: '일', type: 'number', maxLength: 2 },
+            { key: 'year', value: partnerBirth.year, placeholder: '2000', suffix: '년', type: 'number', maxLength: 4 },
+            { key: 'month', value: partnerBirth.month, placeholder: '1', suffix: '월', type: 'number', maxLength: 2 },
+            { key: 'day', value: partnerBirth.day, placeholder: '1', suffix: '일', type: 'number', maxLength: 2 },
           ]}
           onChange={(key, value) => {
-            if (key === 'year') setYear(value);
-            else if (key === 'month') setMonth(value);
-            else if (key === 'day') setDay(value);
+            if (key === 'year') setPartnerBirth({ year: value });
+            else if (key === 'month') setPartnerBirth({ month: value });
+            else if (key === 'day') setPartnerBirth({ day: value });
           }}
         />
 
@@ -108,18 +101,18 @@ export default function Question4() {
           size="sm"
           label="태어난 시간"
           checkLabel="잘 모르겠어요"
-          checked={unknownTime}
-          onCheck={setUnknownTime}
+          checked={partnerBirth.unknownTime}
+          onCheck={(checked) => setPartnerBirth({ unknownTime: checked })}
         />
 
         {/* 시간 입력 */}
         <div style={{ padding: '0 20px 20px' }}>
           <InputField
             type="text"
-            value={birthTime}
-            onChange={setBirthTime}
+            value={partnerBirth.birthTime}
+            onChange={(value) => setPartnerBirth({ birthTime: value })}
             placeholder="00 : 00"
-            disabled={unknownTime}
+            disabled={partnerBirth.unknownTime}
           />
         </div>
 
@@ -142,8 +135,8 @@ export default function Question4() {
             { label: '밝은 편이다', value: 'light' },
             { label: '어두운 편이다', value: 'dark' },
           ]}
-          selectedValue={hairColor}
-          onSelect={setHairColor}
+          selectedValue={partnerBirth.hairColor}
+          onSelect={(value) => setPartnerBirth({ hairColor: value })}
         />
 
         {/* 눈동자 색상 선택 */}
@@ -155,8 +148,8 @@ export default function Question4() {
             { label: '노란편이다', value: 'yellow' },
             { label: '푸른편이다', value: 'blue' },
           ]}
-          selectedValue={eyeColor}
-          onSelect={setEyeColor}
+          selectedValue={partnerBirth.eyeColor}
+          onSelect={(value) => setPartnerBirth({ eyeColor: value })}
         />
 
         {/* 피부색 선택 */}
@@ -168,8 +161,8 @@ export default function Question4() {
             { label: '하얀 편이다', value: 'white' },
             { label: '어두운 편이다', value: 'dark' },
           ]}
-          selectedValue={skinColor}
-          onSelect={setSkinColor}
+          selectedValue={partnerBirth.skinColor}
+          onSelect={(value) => setPartnerBirth({ skinColor: value })}
         />
       </div>
 

--- a/src/app/test/question/5/page.tsx
+++ b/src/app/test/question/5/page.tsx
@@ -1,20 +1,18 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import { Header } from "@/design-system/components/Header/Header";
 import { Title } from "@/design-system/components/Title";
 import { InputFieldGroup } from "@/design-system/components/InputFieldGroup";
 import { CTAButtonGroup } from "@/design-system/components/CTAButtonGroup";
 import { colors } from "@/design-system/foundations/colors";
+import { useTestStore } from "@/store/useTestStore";
 
 export default function Question5() {
   const router = useRouter();
-  const [year, setYear] = useState("");
-  const [month, setMonth] = useState("");
-  const [day, setDay] = useState("");
+  const { loveDate, setLoveDate } = useTestStore();
 
-  const isFormValid = year && month && day;
+  const isFormValid = loveDate.year && loveDate.month && loveDate.day;
 
   const handleNext = () => {
     if (isFormValid) {
@@ -84,14 +82,14 @@ export default function Question5() {
           size="md"
           label="사랑에 빠진 날"
           items={[
-            { key: 'year', value: year, placeholder: '2000', suffix: '년', type: 'number', maxLength: 4 },
-            { key: 'month', value: month, placeholder: '1', suffix: '월', type: 'number', maxLength: 2 },
-            { key: 'day', value: day, placeholder: '1', suffix: '일', type: 'number', maxLength: 2 },
+            { key: 'year', value: loveDate.year, placeholder: '2000', suffix: '년', type: 'number', maxLength: 4 },
+            { key: 'month', value: loveDate.month, placeholder: '1', suffix: '월', type: 'number', maxLength: 2 },
+            { key: 'day', value: loveDate.day, placeholder: '1', suffix: '일', type: 'number', maxLength: 2 },
           ]}
           onChange={(key, value) => {
-            if (key === 'year') setYear(value);
-            else if (key === 'month') setMonth(value);
-            else if (key === 'day') setDay(value);
+            if (key === 'year') setLoveDate({ year: value });
+            else if (key === 'month') setLoveDate({ month: value });
+            else if (key === 'day') setLoveDate({ day: value });
           }}
         />
       </div>

--- a/src/store/useTestStore.ts
+++ b/src/store/useTestStore.ts
@@ -1,0 +1,138 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+// Q1: 사용자 정보
+interface UserInfo {
+  gender: string;
+  name: string;
+}
+
+// Q2: 사용자 생년월일/시간
+interface UserBirth {
+  year: string;
+  month: string;
+  day: string;
+  unknownTime: boolean;
+  birthTime: string;
+}
+
+// Q3: 상대방 정보
+interface PartnerInfo {
+  gender: string;
+  name: string;
+}
+
+// Q4: 상대방 생년월일/시간 + 추가 정보
+interface PartnerBirth {
+  year: string;
+  month: string;
+  day: string;
+  unknownTime: boolean;
+  birthTime: string;
+  hairColor: string;
+  eyeColor: string;
+  skinColor: string;
+}
+
+// Q5: 사랑에 빠진 날
+interface LoveDate {
+  year: string;
+  month: string;
+  day: string;
+}
+
+interface TestState {
+  // Q1 데이터
+  userInfo: UserInfo;
+  setUserInfo: (info: Partial<UserInfo>) => void;
+
+  // Q2 데이터
+  userBirth: UserBirth;
+  setUserBirth: (birth: Partial<UserBirth>) => void;
+
+  // Q3 데이터
+  partnerInfo: PartnerInfo;
+  setPartnerInfo: (info: Partial<PartnerInfo>) => void;
+
+  // Q4 데이터
+  partnerBirth: PartnerBirth;
+  setPartnerBirth: (birth: Partial<PartnerBirth>) => void;
+
+  // Q5 데이터
+  loveDate: LoveDate;
+  setLoveDate: (date: Partial<LoveDate>) => void;
+
+  // 전체 초기화
+  resetAll: () => void;
+}
+
+const initialState = {
+  userInfo: {
+    gender: '',
+    name: '',
+  },
+  userBirth: {
+    year: '',
+    month: '',
+    day: '',
+    unknownTime: false,
+    birthTime: '',
+  },
+  partnerInfo: {
+    gender: '',
+    name: '',
+  },
+  partnerBirth: {
+    year: '',
+    month: '',
+    day: '',
+    unknownTime: false,
+    birthTime: '',
+    hairColor: '',
+    eyeColor: '',
+    skinColor: '',
+  },
+  loveDate: {
+    year: '',
+    month: '',
+    day: '',
+  },
+};
+
+export const useTestStore = create<TestState>()(
+  persist(
+    (set) => ({
+      ...initialState,
+
+      setUserInfo: (info) =>
+        set((state) => ({
+          userInfo: { ...state.userInfo, ...info },
+        })),
+
+      setUserBirth: (birth) =>
+        set((state) => ({
+          userBirth: { ...state.userBirth, ...birth },
+        })),
+
+      setPartnerInfo: (info) =>
+        set((state) => ({
+          partnerInfo: { ...state.partnerInfo, ...info },
+        })),
+
+      setPartnerBirth: (birth) =>
+        set((state) => ({
+          partnerBirth: { ...state.partnerBirth, ...birth },
+        })),
+
+      setLoveDate: (date) =>
+        set((state) => ({
+          loveDate: { ...state.loveDate, ...date },
+        })),
+
+      resetAll: () => set(initialState),
+    }),
+    {
+      name: 'test-storage',
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

  - Zustand store를 활용하여 테스트 페이지(Q1~Q5)의 상태 관리 구현
  - persist middleware를 통해 localStorage에 상태 저장, 뒤로가기 시에도 입력값 유지
  - Q1~Q5 페이지에서 로컬 useState 대신 전역 store 사용하도록 리팩토링

##  Changes

###  신규 파일
  - src/store/useTestStore.ts: Zustand store 생성
    - UserInfo: 사용자 성별, 이름 (Q1)
    - UserBirth: 사용자 생년월일, 태어난 시간 (Q2)
    - PartnerInfo: 상대방 성별, 이름 (Q3)
    - PartnerBirth: 상대방 생년월일, 시간, 머리색/눈동자/피부색 (Q4)
    - LoveDate: 사랑에 빠진 날 (Q5)
    - resetAll(): 전체 초기화 함수

 ### 수정 파일

  - src/app/test/question/1/page.tsx: useTestStore의 userInfo 사용
  - src/app/test/question/2/page.tsx: useTestStore의 userBirth 사용
  - src/app/test/question/3/page.tsx: useTestStore의 partnerInfo 사용
  - src/app/test/question/4/page.tsx: useTestStore의 partnerBirth 사용
  - src/app/test/question/5/page.tsx: useTestStore의 loveDate 사용

### Demo
||
|-|
|<video src="https://github.com/user-attachments/assets/f6323b6c-23ee-4470-b3f7-ae10f5c990a0"/>|

