### PR TITLE
페이지 레이아웃 max-w-md 적용 및 레이블 왼쪽 정렬

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,41 +16,43 @@ export default function Home() {
       className="flex min-h-screen flex-col items-center p-6"
       style={{ backgroundColor: colors.background.main }}
     >
-      <Header
+      <div className="max-w-md w-full flex flex-col items-center">
+        <Header
         type="screenInfo"
         title="그녀와 나의 궁합은?!"
         currentPage={1}
         totalPage={4}
         showBackButton={false}
         showIndicator={false}
-        className="fixed top-0 left-0 right-0 z-50"
-      />
+          className="fixed top-0 left-0 right-0 z-50"
+        />
 
-      {/* Header 높이(52px) + 40px 공백 */}
-      <div style={{ height: '92px' }} />
+        {/* Header 높이(52px) + 40px 공백 */}
+        <div style={{ height: '92px' }} />
 
-      {/* 임시 그래픽 영역 */}
-      <div
-        className="w-full flex items-center justify-center -mx-6"
-        style={{
-          height: '188px',
-          backgroundColor: colors.violet[50],
-          width: 'calc(100% + 48px)',
-        }}
-      >
-        <span style={{ color: colors.neutral[500] }}>그래픽 (변경예정)</span>
+        {/* 임시 그래픽 영역 */}
+        <div
+          className="w-full flex items-center justify-center -mx-6"
+          style={{
+            height: '188px',
+            backgroundColor: colors.violet[50],
+            width: 'calc(100% + 48px)',
+          }}
+        >
+          <span style={{ color: colors.neutral[500] }}>그래픽 (변경예정)</span>
+        </div>
+
+        {/* 20px 공백 */}
+        <div style={{ height: '20px' }} />
+
+        {/* ScoreText */}
+        <ScoreText
+          type="result"
+          badgeText="짝사랑 하는 그녀... 나와 잘될 수 있을까?"
+          title="그녀와 나의 궁합은?!"
+          description={"그녀의 생일을 입력하고\n나와의 궁합을 쉽게 확인해보세요!"}
+        />
       </div>
-
-      {/* 20px 공백 */}
-      <div style={{ height: '20px' }} />
-
-      {/* ScoreText */}
-      <ScoreText
-        type="result"
-        badgeText="짝사랑 하는 그녀... 나와 잘될 수 있을까?"
-        title="그녀와 나의 궁합은?!"
-        description={"그녀의 생일을 입력하고\n나와의 궁합을 쉽게 확인해보세요!"}
-      />
 
       {/* 하단 고정 영역 */}
       <div className="fixed bottom-0 left-0 right-0 flex flex-col items-center">

--- a/src/app/test/question/1/page.tsx
+++ b/src/app/test/question/1/page.tsx
@@ -22,7 +22,7 @@ export default function Question1() {
   };
 
   return (
-    <div style={{ backgroundColor: colors.background.main, minHeight: '100vh' }}>
+    <div style={{ backgroundColor: colors.background.main, minHeight: '100vh' }} className="flex flex-col items-center">
       {/* 상단 고정 Header */}
       <div
         style={{
@@ -34,17 +34,20 @@ export default function Question1() {
           backgroundColor: colors.background.main,
         }}
       >
-        <Header
-          type="progressBar"
-          currentPage={1}
-          totalPage={5}
-          progress={20}
-          onBackClick={() => router.back()}
-        />
+        <div className="max-w-md w-full mx-auto">
+          <Header
+            type="progressBar"
+            currentPage={1}
+            totalPage={5}
+            progress={20}
+            onBackClick={() => router.back()}
+          />
+        </div>
       </div>
 
       {/* 스크롤 가능한 콘텐츠 영역 */}
       <div
+        className="max-w-md w-full"
         style={{
           paddingTop: '52px',
           paddingBottom: '100px',
@@ -95,6 +98,7 @@ export default function Question1() {
           type="single"
           size="md"
           label="내 이름"
+          align="start"
           items={[
             { key: 'name', value: userInfo.name, placeholder: '홍길동' },
           ]}
@@ -107,12 +111,14 @@ export default function Question1() {
         className="fixed bottom-0 left-0 right-0"
         style={{ backgroundColor: colors.background.main }}
       >
-        <CTAButtonGroup
+        <div className="max-w-md w-full mx-auto">
+          <CTAButtonGroup
           type="oneButton"
           primaryButtonText="다음"
           primaryDisabled={!isFormValid}
-          onPrimaryClick={handleNext}
-        />
+            onPrimaryClick={handleNext}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/test/question/2/page.tsx
+++ b/src/app/test/question/2/page.tsx
@@ -24,7 +24,7 @@ export default function Question2() {
   };
 
   return (
-    <div style={{ backgroundColor: colors.background.main, minHeight: '100vh' }}>
+    <div style={{ backgroundColor: colors.background.main, minHeight: '100vh' }} className="flex flex-col items-center">
       {/* 상단 고정 Header */}
       <div
         style={{
@@ -36,17 +36,20 @@ export default function Question2() {
           backgroundColor: colors.background.main,
         }}
       >
-        <Header
-          type="progressBar"
-          currentPage={2}
-          totalPage={5}
-          progress={40}
-          onBackClick={() => router.back()}
-        />
+        <div className="max-w-md w-full mx-auto">
+          <Header
+            type="progressBar"
+            currentPage={2}
+            totalPage={5}
+            progress={40}
+            onBackClick={() => router.back()}
+          />
+        </div>
       </div>
 
       {/* 스크롤 가능한 콘텐츠 영역 */}
       <div
+        className="max-w-md w-full"
         style={{
           paddingTop: '52px',
           paddingBottom: '100px',
@@ -84,6 +87,7 @@ export default function Question2() {
           type="multi"
           size="md"
           label="생년월일"
+          align="start"
           items={[
             { key: 'year', value: userBirth.year, placeholder: '2000', suffix: '년', type: 'number', maxLength: 4 },
             { key: 'month', value: userBirth.month, placeholder: '1', suffix: '월', type: 'number', maxLength: 2 },
@@ -124,12 +128,14 @@ export default function Question2() {
         className="fixed bottom-0 left-0 right-0"
         style={{ backgroundColor: colors.background.main }}
       >
-        <CTAButtonGroup
-          type="oneButton"
-          primaryButtonText="다음"
-          primaryDisabled={!isFormValid}
-          onPrimaryClick={handleNext}
-        />
+        <div className="max-w-md w-full mx-auto">
+          <CTAButtonGroup
+            type="oneButton"
+            primaryButtonText="다음"
+            primaryDisabled={!isFormValid}
+            onPrimaryClick={handleNext}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/test/question/3/page.tsx
+++ b/src/app/test/question/3/page.tsx
@@ -22,7 +22,7 @@ export default function Question3() {
   };
 
   return (
-    <div style={{ backgroundColor: colors.background.main, minHeight: '100vh' }}>
+    <div style={{ backgroundColor: colors.background.main, minHeight: '100vh' }} className="flex flex-col items-center">
       {/* 상단 고정 Header */}
       <div
         style={{
@@ -34,17 +34,20 @@ export default function Question3() {
           backgroundColor: colors.background.main,
         }}
       >
-        <Header
-          type="progressBar"
-          currentPage={3}
-          totalPage={5}
-          progress={60}
-          onBackClick={() => router.back()}
-        />
+        <div className="max-w-md w-full mx-auto">
+          <Header
+            type="progressBar"
+            currentPage={3}
+            totalPage={5}
+            progress={60}
+            onBackClick={() => router.back()}
+          />
+        </div>
       </div>
 
       {/* 스크롤 가능한 콘텐츠 영역 */}
       <div
+        className="max-w-md w-full"
         style={{
           paddingTop: '52px',
           paddingBottom: '100px',
@@ -95,6 +98,7 @@ export default function Question3() {
           type="single"
           size="md"
           label="그녀의 이름"
+          align="start"
           items={[
             { key: 'name', value: partnerInfo.name, placeholder: '홍길동' },
           ]}
@@ -107,12 +111,14 @@ export default function Question3() {
         className="fixed bottom-0 left-0 right-0"
         style={{ backgroundColor: colors.background.main }}
       >
-        <CTAButtonGroup
-          type="oneButton"
-          primaryButtonText="다음"
-          primaryDisabled={!isFormValid}
-          onPrimaryClick={handleNext}
-        />
+        <div className="max-w-md w-full mx-auto">
+          <CTAButtonGroup
+            type="oneButton"
+            primaryButtonText="다음"
+            primaryDisabled={!isFormValid}
+            onPrimaryClick={handleNext}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/test/question/4/page.tsx
+++ b/src/app/test/question/4/page.tsx
@@ -24,7 +24,7 @@ export default function Question4() {
   };
 
   return (
-    <div style={{ backgroundColor: colors.background.main, minHeight: '100vh' }}>
+    <div style={{ backgroundColor: colors.background.main, minHeight: '100vh' }} className="flex flex-col items-center">
       {/* 상단 고정 Header */}
       <div
         style={{
@@ -36,17 +36,20 @@ export default function Question4() {
           backgroundColor: colors.background.main,
         }}
       >
-        <Header
-          type="progressBar"
-          currentPage={4}
-          totalPage={5}
-          progress={80}
-          onBackClick={() => router.back()}
-        />
+        <div className="max-w-md w-full mx-auto">
+          <Header
+            type="progressBar"
+            currentPage={4}
+            totalPage={5}
+            progress={80}
+            onBackClick={() => router.back()}
+          />
+        </div>
       </div>
 
       {/* 스크롤 가능한 콘텐츠 영역 */}
       <div
+        className="max-w-md w-full"
         style={{
           paddingTop: '52px',
           paddingBottom: '100px',
@@ -84,6 +87,7 @@ export default function Question4() {
           type="multi"
           size="md"
           label="생년월일"
+          align="start"
           items={[
             { key: 'year', value: partnerBirth.year, placeholder: '2000', suffix: '년', type: 'number', maxLength: 4 },
             { key: 'month', value: partnerBirth.month, placeholder: '1', suffix: '월', type: 'number', maxLength: 2 },
@@ -173,12 +177,14 @@ export default function Question4() {
         className="fixed bottom-0 left-0 right-0"
         style={{ backgroundColor: colors.background.main }}
       >
-        <CTAButtonGroup
-          type="oneButton"
-          primaryButtonText="다음"
-          primaryDisabled={!isFormValid}
-          onPrimaryClick={handleNext}
-        />
+        <div className="max-w-md w-full mx-auto">
+          <CTAButtonGroup
+            type="oneButton"
+            primaryButtonText="다음"
+            primaryDisabled={!isFormValid}
+            onPrimaryClick={handleNext}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/test/question/5/page.tsx
+++ b/src/app/test/question/5/page.tsx
@@ -22,7 +22,7 @@ export default function Question5() {
   };
 
   return (
-    <div style={{ backgroundColor: colors.background.main, minHeight: '100vh' }}>
+    <div style={{ backgroundColor: colors.background.main, minHeight: '100vh' }} className="flex flex-col items-center">
       {/* 상단 고정 Header */}
       <div
         style={{
@@ -34,17 +34,20 @@ export default function Question5() {
           backgroundColor: colors.background.main,
         }}
       >
-        <Header
-          type="progressBar"
-          currentPage={5}
-          totalPage={5}
-          progress={100}
-          onBackClick={() => router.back()}
-        />
+        <div className="max-w-md w-full mx-auto">
+          <Header
+            type="progressBar"
+            currentPage={5}
+            totalPage={5}
+            progress={100}
+            onBackClick={() => router.back()}
+          />
+        </div>
       </div>
 
       {/* 스크롤 가능한 콘텐츠 영역 */}
       <div
+        className="max-w-md w-full"
         style={{
           paddingTop: '52px',
           paddingBottom: '100px',
@@ -82,6 +85,7 @@ export default function Question5() {
           type="multi"
           size="md"
           label="사랑에 빠진 날"
+          align="start"
           items={[
             { key: 'year', value: loveDate.year, placeholder: '2000', suffix: '년', type: 'number', maxLength: 4 },
             { key: 'month', value: loveDate.month, placeholder: '1', suffix: '월', type: 'number', maxLength: 2 },
@@ -101,12 +105,14 @@ export default function Question5() {
         className="fixed bottom-0 left-0 right-0"
         style={{ backgroundColor: colors.background.main }}
       >
-        <CTAButtonGroup
-          type="oneButton"
-          primaryButtonText="테스트 결과 확인"
-          primaryDisabled={!isFormValid}
-          onPrimaryClick={handleNext}
-        />
+        <div className="max-w-md w-full mx-auto">
+          <CTAButtonGroup
+            type="oneButton"
+            primaryButtonText="테스트 결과 확인"
+            primaryDisabled={!isFormValid}
+            onPrimaryClick={handleNext}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
  Summary
  - 모든 페이지에 max-w-md (448px) 최대 너비 제한 적용하여 넓은 화면에서도 일관된 레이아웃 유지
  - InputFieldGroup 컴포넌트의 레이블을 왼쪽 정렬로 변경

  Changes
  max-w-md 적용
  - src/app/page.tsx: 메인 컨텐츠 영역에 max-w-md 래퍼 추가
  - src/app/test/question/1~5/page.tsx: Header, 콘텐츠, CTA 버튼 영역에 max-w-md 적용

  레이블 왼쪽 정렬
  - 모든 InputFieldGroup에 align="start" 추가
    - 내 이름, 생년월일, 그녀의 이름, 사랑에 빠진 날 등