### PR TITLE
Main page CTAButtonGroup props 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,24 +56,27 @@ export default function Home() {
 
       {/* 하단 고정 영역 */}
       <div className="fixed bottom-0 left-0 right-0 flex flex-col items-center">
-        {/* 참여 인원 표시 */}
-        <div style={{ marginBottom: '12px', pointerEvents: 'none' }}>
-          <MoreBtn showIcon={false}>
-            지금까지 <span style={{ color: '#D8DCE2' }}>389</span>명이 참여했어요
-          </MoreBtn>
-        </div>
+        <div className="max-w-md w-full flex flex-col items-center">
+          {/* 참여 인원 표시 */}
+          <div style={{ marginBottom: '12px', pointerEvents: 'none' }}>
+            <MoreBtn showIcon={false}>
+              지금까지 <span style={{ color: '#D8DCE2' }}>389</span>명이 참여했어요
+            </MoreBtn>
+          </div>
 
-        {/* CTA 버튼 그룹 */}
-        <CTAButtonGroup
-          type="twoButton"
-          primaryButtonText="테스트 시작하기"
-          onPrimaryClick={() => {
-            resetAll();
-            router.push('/test/question/1');
-          }}
-          tertiaryButtonText="공유하기"
-          onTertiaryClick={() => {}}
-        />
+          {/* CTA 버튼 그룹 */}
+          <CTAButtonGroup
+            type="twoButton"
+            primaryButtonText="테스트 시작하기"
+            onPrimaryClick={() => {
+              resetAll();
+              router.push('/test/question/1');
+            }}
+            secondButtonType="tertiary"
+            secondButtonText="공유하기"
+            onSecondButtonClick={() => {}}
+          />
+        </div>
       </div>
 
     </main>


### PR DESCRIPTION
 Summary

  - 메인 페이지의 CTAButtonGroup 컴포넌트 props를 올바르게 수정
  - 하단 고정 영역에 max-w-md 적용하여 레이아웃 일관성 확보

  Changes

  CTAButtonGroup props 수정

  - tertiaryButtonText → secondButtonText (올바른 prop명으로 변경)
  - onTertiaryClick → onSecondButtonClick (올바른 prop명으로 변경)
  - secondButtonType="tertiary" 명시적 추가

  레이아웃 개선

  - 하단 고정 영역(참여 인원 표시 + CTA 버튼)에 max-w-md 래퍼 추가