### PR TITLE
존재하지 않는 assets 모듈 export 제거

### DIFF
--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -11,8 +11,5 @@ export * from './foundations';
 // Components
 export * from './components';
 
-// Assets (Icons, Images, etc.)
-export * from './assets';
-
 // Utils
 export * from './utils';


### PR DESCRIPTION
- design-system/index.ts에서 존재하지 않는 ./assets 모듈 export 제거
- pnpm build 시 발생하던 타입 에러 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)