### PR TITLE
Android WebView 뷰포트 높이 문제 해결

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,16 @@ body {
   color: var(--text-main);
   background-color: var(--background-main);
   font-family: 'Wanted Sans', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  height: 100%;
+  min-height: 100%;
+  min-height: -webkit-fill-available;
+}
+
+/* Android WebView 및 모바일 브라우저 뷰포트 대응 */
+@supports (height: 100dvh) {
+  html, body {
+    min-height: 100dvh;
+  }
 }
 
 @layer utilities {

--- a/src/app/result/_components/ResultLoading.tsx
+++ b/src/app/result/_components/ResultLoading.tsx
@@ -6,13 +6,15 @@ import { ScoreText } from "@/design-system/components/ScoreText";
 export function ResultLoading() {
   return (
     <main
-      className="flex min-h-screen flex-col items-center"
+      className="flex flex-col items-center"
       style={{
         backgroundColor: colors.background.main,
         backgroundImage: 'url(/images/loading-background.png)',
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         backgroundRepeat: 'no-repeat',
+        minHeight: '100dvh',
+        height: '100%',
       }}
     >
       {/* ScoreText - 상단 26px 여백 */}

--- a/src/app/result/_components/ResultReady.tsx
+++ b/src/app/result/_components/ResultReady.tsx
@@ -10,12 +10,14 @@ interface ResultReadyProps {
 
 export function ResultReady({ onConfirm }: ResultReadyProps) {
   return (
-    <div style={{ position: 'relative', minHeight: '100vh' }}>
+    <div style={{ position: 'relative', minHeight: '100dvh', height: '100%' }}>
       <main
-        className="flex min-h-screen flex-col items-center"
+        className="flex flex-col items-center"
         style={{
           backgroundColor: colors.background.main,
           paddingBottom: '140px',
+          minHeight: '100dvh',
+          height: '100%',
         }}
       >
         {/* ScoreText - 상단 26px 여백 */}

--- a/src/app/result/_components/ResultReadyIntro.tsx
+++ b/src/app/result/_components/ResultReadyIntro.tsx
@@ -10,12 +10,14 @@ interface ResultReadyIntroProps {
 
 export function ResultReadyIntro({ onNext }: ResultReadyIntroProps) {
   return (
-    <div style={{ position: 'relative', minHeight: '100vh' }}>
+    <div style={{ position: 'relative', minHeight: '100dvh', height: '100%' }}>
       <main
-        className="flex min-h-screen flex-col items-center"
+        className="flex flex-col items-center"
         style={{
           backgroundColor: colors.background.main,
           paddingBottom: '140px',
+          minHeight: '100dvh',
+          height: '100%',
         }}
       >
         {/* ScoreText - 상단 26px 여백 */}


### PR DESCRIPTION
- 100vh를 100dvh로 변경하여 실제 가시 영역 높이 사용
- html, body에 height: 100% 및 100dvh 지원 추가
- ResultLoading, ResultReady, ResultReadyIntro 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)