### PR TITLE
fix: Result 화면 배경 이미지 정책 변경 및 모바일 상단 여백 조정

### DIFF
--- a/src/app/result/_components/ResultLoading.tsx
+++ b/src/app/result/_components/ResultLoading.tsx
@@ -1,24 +1,32 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { colors } from "@/design-system/foundations/colors";
 import { ScoreText } from "@/design-system/components/ScoreText";
+import { isMobileDevice } from "@/utils/device";
 
 export function ResultLoading() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    setIsMobile(isMobileDevice());
+  }, []);
+
   return (
     <main
       className="flex flex-col items-center"
       style={{
         backgroundColor: colors.background.main,
         backgroundImage: 'url(/images/loading-background.png)',
-        backgroundSize: 'cover',
+        backgroundSize: 'auto 100%',
         backgroundPosition: 'center',
         backgroundRepeat: 'no-repeat',
         minHeight: '100dvh',
         height: '100%',
       }}
     >
-      {/* ScoreText - 상단 26px 여백 */}
-      <div style={{ paddingTop: '26px', width: '100%' }}>
+      {/* ScoreText - 상단 여백 (모바일: 64px, 웹: 26px) */}
+      <div style={{ paddingTop: isMobile ? '64px' : '26px', width: '100%' }}>
         <ScoreText
           type="loading"
           badgeText="me 🩷 her"

--- a/src/app/result/_components/ResultReady.tsx
+++ b/src/app/result/_components/ResultReady.tsx
@@ -1,14 +1,22 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { colors } from "@/design-system/foundations/colors";
 import { ScoreText } from "@/design-system/components/ScoreText";
 import { ScratchOrb } from "./ScratchOrb";
+import { isMobileDevice } from "@/utils/device";
 
 interface ResultReadyProps {
   onConfirm: () => void;
 }
 
 export function ResultReady({ onConfirm }: ResultReadyProps) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    setIsMobile(isMobileDevice());
+  }, []);
+
   return (
     <div style={{ position: 'relative', minHeight: '100dvh', height: '100%' }}>
       <main
@@ -20,8 +28,8 @@ export function ResultReady({ onConfirm }: ResultReadyProps) {
           height: '100%',
         }}
       >
-        {/* ScoreText - 상단 26px 여백 */}
-        <div style={{ paddingTop: '26px', width: '100%' }}>
+        {/* ScoreText - 상단 여백 (모바일: 64px, 웹: 26px) */}
+        <div style={{ paddingTop: isMobile ? '64px' : '26px', width: '100%' }}>
           <ScoreText
             type="loading"
             badgeText="분석완료"

--- a/src/app/result/_components/ResultReadyIntro.tsx
+++ b/src/app/result/_components/ResultReadyIntro.tsx
@@ -1,14 +1,22 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { colors } from "@/design-system/foundations/colors";
 import { ScoreText } from "@/design-system/components/ScoreText";
 import { Tooltip } from "@/design-system/components/Tooltip";
+import { isMobileDevice } from "@/utils/device";
 
 interface ResultReadyIntroProps {
   onNext: () => void;
 }
 
 export function ResultReadyIntro({ onNext }: ResultReadyIntroProps) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    setIsMobile(isMobileDevice());
+  }, []);
+
   return (
     <div style={{ position: 'relative', minHeight: '100dvh', height: '100%' }}>
       <main
@@ -20,8 +28,8 @@ export function ResultReadyIntro({ onNext }: ResultReadyIntroProps) {
           height: '100%',
         }}
       >
-        {/* ScoreText - 상단 26px 여백 */}
-        <div style={{ paddingTop: '26px', width: '100%' }}>
+        {/* ScoreText - 상단 여백 (모바일: 64px, 웹: 26px) */}
+        <div style={{ paddingTop: isMobile ? '64px' : '26px', width: '100%' }}>
           <ScoreText
             type="loading"
             badgeText="분석완료"


### PR DESCRIPTION
- ResultLoading 배경 이미지를 세로 기준으로 맞추고 가로는 잘리도록 변경 (cover → auto 100%)
- ResultLoading, ResultReady, ResultReadyIntro 상단 여백을 모바일일 때 64px로 조정

#36 

🤖 Generated with [Claude Code](https://claude.com/claude-code)