### PR TITLE
shareComplete API를 메인 페이지 진입 시 호출하도록 변경

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,11 +12,12 @@ import { useTestStore } from "@/store/useTestStore";
 import { shareRootUrl } from "@/utils/share";
 import { isNativeApp } from "@/utils/device";
 import { close } from "@/utils/bridge";
+import { postShareComplete } from "@/api/share";
 
 export default function Home() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { resetAll, setShareToken } = useTestStore();
+  const { resetAll } = useTestStore();
   const [isApp, setIsApp] = useState(false);
   const [showExitModal, setShowExitModal] = useState(false);
 
@@ -27,9 +28,19 @@ export default function Home() {
   useEffect(() => {
     const token = searchParams.get('shareToken');
     if (token) {
-      setShareToken(token);
+      postShareComplete(token)
+        .then((response) => {
+          if (process.env.NODE_ENV === 'development') {
+            console.log('[Home] ShareComplete API Success:', response);
+          }
+        })
+        .catch((error) => {
+          if (process.env.NODE_ENV === 'development') {
+            console.error('[Home] ShareComplete API Error:', error);
+          }
+        });
     }
-  }, [searchParams, setShareToken]);
+  }, [searchParams]);
 
   const handleShare = async () => {
     const result = await shareRootUrl();

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -5,7 +5,6 @@ import { ResultLoading, ResultReady, ResultPreview, ResultContent, ResultError }
 import { useTestStore } from "@/store/useTestStore";
 import { isNativeApp } from "@/utils/device";
 import { postLoveTest, mapStoreToRequest, LoveTestResponse } from "@/api/loveTest";
-import { postShareComplete } from "@/api/share";
 
 type ResultStep = 'loading' | 'ready' | 'preview' | 'content' | 'error';
 
@@ -25,7 +24,7 @@ function validateStoreData(
 
 export default function Result() {
   const [step, setStep] = useState<ResultStep>('loading');
-  const { userInfo, userBirth, partnerInfo, partnerBirth, loveDate, hasShared, shareToken } = useTestStore();
+  const { userInfo, userBirth, partnerInfo, partnerBirth, loveDate, hasShared } = useTestStore();
   const [isApp, setIsApp] = useState(false);
   const [apiResult, setApiResult] = useState<LoveTestResponse | null>(null);
   const [isApiLoaded, setIsApiLoaded] = useState(false);
@@ -77,14 +76,8 @@ export default function Result() {
         loveDate,
       });
       try {
-        const apiCalls: Promise<unknown>[] = [postLoveTest(request)];
-
-        if (shareToken) {
-          apiCalls.push(postShareComplete(shareToken));
-        }
-
-        const [loveTestResponse] = await Promise.all(apiCalls);
-        setApiResult(loveTestResponse as LoveTestResponse);
+        const response = await postLoveTest(request);
+        setApiResult(response);
       } catch (error) {
         if (process.env.NODE_ENV === 'development') {
           console.error('[Result] LoveTest API Error:', error);
@@ -97,7 +90,7 @@ export default function Result() {
     };
 
     fetchResult();
-  }, [step, shareToken]);
+  }, [step]);
 
   // API 응답 완료 + 최소 로딩 시간 경과 시 다음 step으로 이동
   useEffect(() => {

--- a/src/store/useTestStore.ts
+++ b/src/store/useTestStore.ts
@@ -67,10 +67,6 @@ interface TestState {
   hasShared: boolean;
   setHasShared: (shared: boolean) => void;
 
-  // 공유 토큰
-  shareToken: string | null;
-  setShareToken: (token: string | null) => void;
-
   // 전체 초기화
   resetAll: () => void;
 }
@@ -108,7 +104,6 @@ const initialState = {
     day: '',
   },
   hasShared: false,
-  shareToken: null,
 };
 
 export const useTestStore = create<TestState>()(
@@ -142,8 +137,6 @@ export const useTestStore = create<TestState>()(
         })),
 
       setHasShared: (shared) => set({ hasShared: shared }),
-
-      setShareToken: (token) => set({ shareToken: token }),
 
       resetAll: () => set(initialState),
     }),


### PR DESCRIPTION
- result 페이지에서 complete API 호출 제거
- 메인 페이지에서 shareToken query parameter 감지 시 바로 API 호출
- store에서 미사용 shareToken 관련 코드 제거