### PR TITLE
worth test api

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'objectstorage.ap-chuncheon-1.oraclecloud.com',
+        pathname: '/n/axircf8nexkb/b/dhc-storage/**',
+      },
+    ],
+  },
   async rewrites() {
     return [
       {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -9,6 +9,11 @@ export async function apiClient<T>(
   options: RequestOptions = {},
 ): Promise<T> {
   const { body, headers, ...restOptions } = options;
+  const method = (restOptions.method ?? 'GET').toUpperCase();
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`[api] → ${method} ${endpoint}`, body ?? '');
+  }
 
   const response = await fetch(`${BASE_URL}${endpoint}`, {
     headers: {
@@ -21,8 +26,19 @@ export async function apiClient<T>(
   });
 
   if (!response.ok) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error(
+        `[api] ✖ ${method} ${endpoint} — ${response.status} ${response.statusText}`,
+      );
+    }
     throw new Error(`API Error: ${response.status} ${response.statusText}`);
   }
 
-  return response.json() as Promise<T>;
+  const data = (await response.json()) as T;
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`[api] ← ${method} ${endpoint}`, data);
+  }
+
+  return data;
 }

--- a/src/api/worthTest/index.ts
+++ b/src/api/worthTest/index.ts
@@ -1,0 +1,96 @@
+import { apiClient } from '../client';
+import {
+  WealthGroupCreateRequest,
+  WealthGroupJoinRequest,
+  WealthTestRequest,
+} from './request';
+import {
+  WealthAgeGroup,
+  WealthGroupCreateResponse,
+  WealthGroupInviteResponse,
+  WealthGroupJoinResponse,
+  WealthGroupRankingResponse,
+  WealthTestResultResponse,
+  WealthTestStatsResponse,
+} from './response';
+
+export type {
+  WealthTestRequest,
+  WealthGroupCreateRequest,
+  WealthGroupJoinRequest,
+} from './request';
+export type {
+  WealthAgeGroup,
+  WealthFortuneEvent,
+  WealthFortuneGraphPoint,
+  WealthFortuneResultResponse,
+  WealthGroupCreateResponse,
+  WealthGroupInviteResponse,
+  WealthGroupJoinResponse,
+  WealthGroupRankingEntry,
+  WealthGroupRankingResponse,
+  WealthTestResultResponse,
+  WealthTestStatsResponse,
+} from './response';
+export { mapStoreToWealthRequest } from './mapper';
+
+export async function postWorthTest(
+  request: WealthTestRequest,
+): Promise<WealthTestResultResponse> {
+  return apiClient<WealthTestResultResponse>('/api/wealth-test', {
+    method: 'POST',
+    body: request,
+  });
+}
+
+export async function getWorthTestResult(
+  resultId: string,
+): Promise<WealthTestResultResponse> {
+  return apiClient<WealthTestResultResponse>(
+    `/api/wealth-test/results/${encodeURIComponent(resultId)}`,
+  );
+}
+
+export async function getWorthTestStats(): Promise<WealthTestStatsResponse> {
+  return apiClient<WealthTestStatsResponse>('/api/wealth-test/stats');
+}
+
+export async function postWorthGroup(
+  request: WealthGroupCreateRequest,
+): Promise<WealthGroupCreateResponse> {
+  return apiClient<WealthGroupCreateResponse>('/api/wealth-test/groups', {
+    method: 'POST',
+    body: request,
+  });
+}
+
+export async function getWorthGroupByInviteCode(
+  inviteCode: string,
+): Promise<WealthGroupInviteResponse> {
+  return apiClient<WealthGroupInviteResponse>(
+    `/api/wealth-test/groups/invite/${encodeURIComponent(inviteCode)}`,
+  );
+}
+
+export async function postWorthGroupJoin(
+  groupId: string,
+  request: WealthGroupJoinRequest,
+): Promise<WealthGroupJoinResponse> {
+  return apiClient<WealthGroupJoinResponse>(
+    `/api/wealth-test/groups/${encodeURIComponent(groupId)}/join`,
+    {
+      method: 'POST',
+      body: request,
+    },
+  );
+}
+
+export async function getWorthGroupRanking(
+  groupId: string,
+  ageGroup: WealthAgeGroup = 'all',
+): Promise<WealthGroupRankingResponse> {
+  const query = new URLSearchParams({ ageGroup }).toString();
+  return apiClient<WealthGroupRankingResponse>(
+    `/api/wealth-test/groups/${encodeURIComponent(groupId)}/ranking?${query}`,
+  );
+}

--- a/src/api/worthTest/mapper.ts
+++ b/src/api/worthTest/mapper.ts
@@ -1,0 +1,54 @@
+import { WealthTestRequest } from './request';
+
+interface StoreUserInfo {
+  gender: string;
+  name: string;
+}
+
+interface StoreUserBirth {
+  year: string;
+  month: string;
+  day: string;
+  unknownTime: boolean;
+  birthTime: string;
+}
+
+interface StoreWealthData {
+  userInfo: StoreUserInfo;
+  userBirth: StoreUserBirth;
+}
+
+function formatDate(year: string, month: string, day: string): string {
+  const y = year.padStart(4, '0');
+  const m = month.padStart(2, '0');
+  const d = day.padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function formatBirthTime(time: string, unknownTime: boolean): string | null {
+  if (unknownTime || !time) {
+    return null;
+  }
+  // "HH:mm:ss"로 들어오면 HH:mm만 사용
+  if (time.length >= 5) {
+    return time.slice(0, 5);
+  }
+  return time;
+}
+
+function mapGender(gender: string): 'MALE' | 'FEMALE' {
+  return gender.toLowerCase() === 'male' ? 'MALE' : 'FEMALE';
+}
+
+export function mapStoreToWealthRequest(data: StoreWealthData): WealthTestRequest {
+  return {
+    name: data.userInfo.name,
+    gender: mapGender(data.userInfo.gender),
+    birthDate: formatDate(
+      data.userBirth.year,
+      data.userBirth.month,
+      data.userBirth.day,
+    ),
+    birthTime: formatBirthTime(data.userBirth.birthTime, data.userBirth.unknownTime),
+  };
+}

--- a/src/api/worthTest/request.ts
+++ b/src/api/worthTest/request.ts
@@ -1,0 +1,17 @@
+type Gender = 'MALE' | 'FEMALE';
+
+export interface WealthTestRequest {
+  name: string;
+  gender: Gender;
+  birthDate: string; // YYYY-MM-DD
+  birthTime?: string | null; // HH:mm (없으면 null)
+}
+
+export interface WealthGroupCreateRequest {
+  groupName: string;
+  resultId?: string | null;
+}
+
+export interface WealthGroupJoinRequest {
+  resultId: string;
+}

--- a/src/api/worthTest/response.ts
+++ b/src/api/worthTest/response.ts
@@ -1,0 +1,76 @@
+export type WealthAgeGroup =
+  | 'all'
+  | '20'
+  | '30'
+  | '40'
+  | '50'
+  | '60'
+  | '70'
+  | '80';
+
+export interface WealthFortuneGraphPoint {
+  age: number;
+  amount: number;
+}
+
+export interface WealthFortuneEvent {
+  age: number;
+  description: string;
+  amount: number;
+  iconUrl: string;
+}
+
+export interface WealthFortuneResultResponse {
+  id: number;
+  fortuneType: string;
+  fortuneTypeDescription: string;
+  fortuneDetail: string;
+  fortuneTypeImageUrl: string;
+  graphData: WealthFortuneGraphPoint[];
+  events: WealthFortuneEvent[];
+}
+
+export interface WealthTestResultResponse {
+  resultId: string;
+  name: string;
+  result: WealthFortuneResultResponse;
+}
+
+export interface WealthTestStatsResponse {
+  totalParticipants: number;
+}
+
+export interface WealthGroupCreateResponse {
+  groupId: string;
+  groupName: string;
+  inviteCode: string;
+  memberCount: number;
+}
+
+export interface WealthGroupInviteResponse {
+  groupId: string;
+  groupName: string;
+  memberCount: number;
+}
+
+export interface WealthGroupJoinResponse {
+  groupId: string;
+  groupName: string;
+  memberCount: number;
+}
+
+export interface WealthGroupRankingEntry {
+  rank: number;
+  resultId: string;
+  name: string;
+  amount: number;
+  result: WealthFortuneResultResponse;
+}
+
+export interface WealthGroupRankingResponse {
+  groupName: string;
+  inviteCode: string;
+  totalMemberCount: number;
+  ageGroup: WealthAgeGroup;
+  rankings: WealthGroupRankingEntry[];
+}

--- a/src/app/love-test/page.tsx
+++ b/src/app/love-test/page.tsx
@@ -33,17 +33,7 @@ function HomeContent() {
   useEffect(() => {
     const token = searchParams.get('shareToken');
     if (token) {
-      postShareComplete(token)
-        .then((response) => {
-          if (process.env.NODE_ENV === 'development') {
-            console.log('[Home] ShareComplete API Success:', response);
-          }
-        })
-        .catch((error) => {
-          if (process.env.NODE_ENV === 'development') {
-            console.error('[Home] ShareComplete API Error:', error);
-          }
-        });
+      postShareComplete(token).catch(() => {});
     }
   }, [searchParams]);
 

--- a/src/app/love-test/result/page.tsx
+++ b/src/app/love-test/result/page.tsx
@@ -78,11 +78,7 @@ export default function Result() {
       try {
         const response = await postLoveTest(request);
         setApiResult(response);
-      } catch (error) {
-        if (process.env.NODE_ENV === 'development') {
-          console.error('[Result] LoveTest API Error:', error);
-          console.error('[Result] Request:', request);
-        }
+      } catch {
         setStep('error');
         return;
       }

--- a/src/app/worth-test/group/create/page.tsx
+++ b/src/app/worth-test/group/create/page.tsx
@@ -4,19 +4,25 @@ import { useRef, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Header } from "@/design-system/components/Header/Header";
 import { Title } from "@/design-system/components/Title";
-import { LabelButton } from "@/design-system/components/LabelButton";
 import { InputFieldGroup } from "@/design-system/components/InputFieldGroup";
 import { CTAButtonGroup } from "@/design-system/components/CTAButtonGroup";
 import { colors } from "@/design-system/foundations/colors";
 import { useTestStore } from "@/store/useTestStore";
 import { QuestionBanner } from "../../question/_components/QuestionBanner";
 import { useScreenImpression, ScreenName } from "@/analytics";
+import { postWorthGroup } from "@/api/worthTest";
 
 export default function Question1() {
   const router = useRouter();
-  const { userInfo, setUserInfo } = useTestStore();
+  const {
+    groupNameInput,
+    setGroupNameInput,
+    worthResultId,
+    setWorthGroup,
+  } = useTestStore();
   const nameInputRef = useRef<HTMLInputElement>(null);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
 
   useScreenImpression(ScreenName.QUESTION_1);
 
@@ -32,11 +38,25 @@ export default function Question1() {
     return () => vv.removeEventListener("resize", handleResize);
   }, []);
 
-  const isFormValid = !!userInfo.name;
+  const isFormValid = !!groupNameInput.trim();
 
-  const handleNext = () => {
-    if (isFormValid) {
-      router.push('/worth-test/group/detail');
+  const handleNext = async () => {
+    if (!isFormValid || submitting) return;
+    setSubmitting(true);
+    try {
+      const response = await postWorthGroup({
+        groupName: groupNameInput.trim(),
+        resultId: worthResultId ?? undefined,
+      });
+      setWorthGroup({
+        groupId: response.groupId,
+        groupName: response.groupName,
+        inviteCode: response.inviteCode,
+      });
+      router.push(`/worth-test/group/detail?groupId=${response.groupId}`);
+    } catch {
+      alert('그룹 생성에 실패했어요. 잠시 후 다시 시도해주세요.');
+      setSubmitting(false);
     }
   };
 
@@ -103,9 +123,9 @@ export default function Question1() {
           label="그룹이름"
           align="start"
           items={[
-            { key: 'name', value: userInfo.name, placeholder: '부자 모임', inputRef: nameInputRef as React.Ref<HTMLInputElement> },
+            { key: 'name', value: groupNameInput, placeholder: '부자 모임', inputRef: nameInputRef as React.Ref<HTMLInputElement> },
           ]}
-          onChange={(_, value) => setUserInfo({ name: value })}
+          onChange={(_, value) => setGroupNameInput(value)}
         />
       </div>
 
@@ -120,9 +140,9 @@ export default function Question1() {
       >
         <div className="max-w-md w-full mx-auto">
           <CTAButtonGroup
-          type="oneButton"
-          primaryButtonText="그룹 생성하기"
-          primaryDisabled={!isFormValid}
+            type="oneButton"
+            primaryButtonText={submitting ? "생성 중..." : "그룹 생성하기"}
+            primaryDisabled={!isFormValid || submitting}
             onPrimaryClick={handleNext}
           />
         </div>

--- a/src/app/worth-test/group/detail/page.tsx
+++ b/src/app/worth-test/group/detail/page.tsx
@@ -1,14 +1,21 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Header } from "@/design-system/components/Header/Header";
-import { RankingPodium } from "@/design-system/components/RankingPodium/RankingPodium";
+import { RankingPodium, RankingEntry } from "@/design-system/components/RankingPodium/RankingPodium";
 import { CTAButtonGroup } from "@/design-system/components/CTAButtonGroup";
 import { shareRootUrl } from "@/utils/share";
 import { colors } from "@/design-system/foundations/colors";
 import { typography } from "@/design-system/foundations/typography";
+import { useTestStore } from "@/store/useTestStore";
+import {
+  getWorthGroupRanking,
+  WealthAgeGroup,
+  WealthGroupRankingEntry,
+  WealthGroupRankingResponse,
+} from "@/api/worthTest";
 
 /** 섹션 타이틀 */
 function SectionTitle({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
@@ -38,7 +45,7 @@ function RankingTop3Section({
 }: {
   sectionTitle: string;
   podiumTitle: string;
-  entries: import("@/design-system/components/RankingPodium/RankingPodium").RankingEntry[];
+  entries: RankingEntry[];
   displayOrder: number[];
 }) {
   return (
@@ -338,69 +345,125 @@ function FortuneDetailRankingSection({
   );
 }
 
-
-const MEMBER_LABELS = ['전체', '20대', '30대', '40대', '50대', '60대', '70대', '80대'];
-
-/** 전체 멤버 랭킹 데이터 (mock) */
-const RANKING_MEMBERS: DetailRankingRow[] = [
-  {
-    rank: 1,
-    name: '금전의길',
-    score: '총 45억원',
-    imageUrl: '/icons/icon_dragon.svg',
-    scoreIconSrc: '/icons/icon-flying-money.svg',
-    fortuneType: {
-      title: '대기만성 거북이형',
-      description: '초년 고생, 말년 풍요: 젊을 때는 금전적 어려움이나 정체기가 있을 수 있으나, 꾸준한 노력으로 내공을 쌓아 늦게 크게 성공합니다.\n\n투자 및 안내: 당장의 작은 이익에 연연하지 않고 장기적인 관점에서 노력과 투자를 지속할 떄 큰 결실을 봅니다.\n\n노력의 산물: 요행을 바라기보다는 묵묵히 자신의 분야에서 역량을 기르면, 그 대가가 뒤늦게 재물로 돌아오는 구조입니다.',
-    },
-  },
-  {
-    rank: 2,
-    name: '부자왕',
-    score: '총 25억원',
-    imageUrl: '/icons/icon_rabbit.svg',
-    scoreIconSrc: '/icons/icon-flying-money.svg',
-    fortuneType: {
-      title: '꾸준한 다람쥐형',
-      description: '초년 고생, 말년 풍요: 젊을 때는 금전적 어려움이나 정체기가 있을 수 있으나, 꾸준한 노력으로 내공을 쌓아 늦게 크게 성공합니다.\n\n투자 및 안내: 당장의 작은 이익에 연연하지 않고 장기적인 관점에서 노력과 투자를 지속할 떄 큰 결실을 봅니다.\n\n노력의 산물: 요행을 바라기보다는 묵묵히 자신의 분야에서 역량을 기르면, 그 대가가 뒤늦게 재물로 돌아오는 구조입니다.',
-    },
-  },
+const MEMBER_LABELS: { label: string; ageGroup: WealthAgeGroup }[] = [
+  { label: '전체', ageGroup: 'all' },
+  { label: '20대', ageGroup: '20' },
+  { label: '30대', ageGroup: '30' },
+  { label: '40대', ageGroup: '40' },
+  { label: '50대', ageGroup: '50' },
+  { label: '60대', ageGroup: '60' },
+  { label: '70대', ageGroup: '70' },
+  { label: '80대', ageGroup: '80' },
 ];
 
-/** TOP 3 포디움용 데이터 생성 (전체 랭킹에서 상위 3명 추출) */
-const TOP3_ENTRIES: import("@/design-system/components/RankingPodium/RankingPodium").RankingEntry[] = [
-  {
-    rank: 1,
-    name: RANKING_MEMBERS[0]?.name,
-    score: RANKING_MEMBERS[0]?.score?.replace('총 ', ''),
+interface Top3Style {
+  barHeight: number;
+  barGradientStartColor?: string;
+  barGradientEndColor?: string;
+  barTextColor?: string;
+}
+
+const TOP3_STYLE_BY_RANK: Record<number, Top3Style> = {
+  1: {
     barHeight: 120,
-    scoreIconSrc: '/icons/icon-flying-money.svg',
     barGradientStartColor: '#B5FFCA',
     barGradientEndColor: 'rgba(109, 153, 143, 0)',
     barTextColor: '#DBFFCE',
-    imageUrl: RANKING_MEMBERS[0]?.imageUrl,
   },
-  {
-    rank: 2,
-    name: RANKING_MEMBERS[1]?.name,
-    score: RANKING_MEMBERS[1]?.score?.replace('총 ', ''),
+  2: {
     barHeight: 90,
-    scoreIconSrc: '/icons/icon-flying-money.svg',
     barGradientStartColor: '#C6B5FF',
     barGradientEndColor: 'rgba(198, 181, 255, 0)',
     barTextColor: '#C3D1F1',
-    imageUrl: RANKING_MEMBERS[1]?.imageUrl,
   },
-  {
-    rank: 3,
+  3: {
     barHeight: 60,
-    scoreIconSrc: '/icons/icon-flying-money.svg',
   },
-];
+};
 
-export default function WorthTestGroupDetail() {
+function formatAmount(amount: number): string {
+  if (amount >= 100000000) {
+    const uk = Math.round(amount / 100000000);
+    return `${uk.toLocaleString()}억원`;
+  }
+  if (amount >= 10000) {
+    const man = Math.round(amount / 10000);
+    return `${man.toLocaleString()}만원`;
+  }
+  return `${amount.toLocaleString()}원`;
+}
+
+function toTop3Entries(
+  rankings: WealthGroupRankingEntry[],
+): RankingEntry[] {
+  return [1, 2, 3].map((rank) => {
+    const entry = rankings.find((e) => e.rank === rank);
+    const style = TOP3_STYLE_BY_RANK[rank] ?? { barHeight: 60 };
+    if (!entry) {
+      return {
+        rank,
+        scoreIconSrc: '/icons/icon-flying-money.svg',
+        ...style,
+      };
+    }
+    return {
+      rank,
+      name: entry.name,
+      score: formatAmount(entry.amount),
+      scoreIconSrc: '/icons/icon-flying-money.svg',
+      ...style,
+    };
+  });
+}
+
+function toDetailRows(rankings: WealthGroupRankingEntry[]): DetailRankingRow[] {
+  return rankings.map((entry) => ({
+    rank: entry.rank,
+    name: entry.name,
+    score: `총 ${formatAmount(entry.amount)}`,
+    imageUrl: entry.result.fortuneTypeImageUrl,
+    scoreIconSrc: '/icons/icon-flying-money.svg',
+    fortuneType: {
+      title: entry.result.fortuneType,
+      description: entry.result.fortuneDetail,
+    },
+  }));
+}
+
+function WorthTestGroupDetailContent() {
   const router = useRouter();
-  const [selectedLabel, setSelectedLabel] = useState(MEMBER_LABELS[0]);
+  const searchParams = useSearchParams();
+  const { worthGroup, setWorthGroup } = useTestStore();
+  const queryGroupId = searchParams.get('groupId');
+  const groupId = queryGroupId ?? worthGroup?.groupId ?? null;
+
+  const [selectedAgeGroup, setSelectedAgeGroup] = useState<WealthAgeGroup>('all');
+  const [ranking, setRanking] = useState<WealthGroupRankingResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!groupId) {
+      setError('그룹 정보를 찾을 수 없어요.');
+      return;
+    }
+    let cancelled = false;
+    getWorthGroupRanking(groupId, selectedAgeGroup)
+      .then((response) => {
+        if (cancelled) return;
+        setRanking(response);
+        setWorthGroup({
+          groupId,
+          groupName: response.groupName,
+          inviteCode: response.inviteCode,
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setError('랭킹을 불러오지 못했어요.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [groupId, selectedAgeGroup, setWorthGroup]);
 
   // 드래그 스크롤
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -429,6 +492,19 @@ export default function WorthTestGroupDetail() {
     isDragging.current = false;
   }, []);
 
+  const top3Entries = useMemo(
+    () => (ranking ? toTop3Entries(ranking.rankings) : []),
+    [ranking],
+  );
+  const detailRows = useMemo(
+    () => (ranking ? toDetailRows(ranking.rankings) : []),
+    [ranking],
+  );
+
+  const headerTitle = ranking
+    ? `${ranking.groupName} 부자랭킹`
+    : '부자랭킹';
+
   return (
     <div
       style={{ backgroundColor: colors.background.main, minHeight: "100vh" }}
@@ -451,7 +527,7 @@ export default function WorthTestGroupDetail() {
         <div className="max-w-md w-full mx-auto">
           <Header
             type="screenInfo"
-            title="부자 모임 부자랭킹"
+            title={headerTitle}
             showBackButton={true}
             showIndicator={false}
             onBackClick={() => router.back()}
@@ -486,12 +562,14 @@ export default function WorthTestGroupDetail() {
             width: 'max-content',
           }}
         >
-          {MEMBER_LABELS.map((label) => {
-            const isSelected = label === selectedLabel;
+          {MEMBER_LABELS.map(({ label, ageGroup }) => {
+            const isSelected = ageGroup === selectedAgeGroup;
             return (
               <button
-                key={label}
-                onClick={() => { if (!hasDragged.current) setSelectedLabel(label); }}
+                key={ageGroup}
+                onClick={() => {
+                  if (!hasDragged.current) setSelectedAgeGroup(ageGroup);
+                }}
                 style={{
                   padding: '8px 17px',
                   backgroundColor: isSelected ? '#D9CEFF' : '#1F2127',
@@ -520,22 +598,43 @@ export default function WorthTestGroupDetail() {
           padding: '0 20px 160px',
         }}
       >
-        {/* 랭킹 TOP 3 */}
-        <RankingTop3Section
-          sectionTitle="전체 금전운 TOP 3"
-          podiumTitle={"금전운이 가장 좋은 3명이애요\n친구들을 더 초대하고 랭킹을 확인해보세요"}
-          entries={TOP3_ENTRIES}
-          displayOrder={[2, 1, 3]}
-        />
+        {error && (
+          <div
+            style={{
+              marginTop: '24px',
+              color: colors.text.bodyPrimary,
+              textAlign: 'center',
+            }}
+          >
+            {error}
+          </div>
+        )}
 
-        {/* 금전운 상세랭킹 */}
-        <FortuneDetailRankingSection
-          sectionTitle="금전운 상세랭킹"
-          rows={RANKING_MEMBERS}
-          buttonText="멤버 추가하기"
-          onButtonClick={() => router.push('/worth-test/question/1?type=member')}
-        />
-        <div style={{ height: '100px' }} />
+        {!error && (
+          <>
+            {/* 랭킹 TOP 3 */}
+            <RankingTop3Section
+              sectionTitle="전체 금전운 TOP 3"
+              podiumTitle={"금전운이 가장 좋은 3명이애요\n친구들을 더 초대하고 랭킹을 확인해보세요"}
+              entries={top3Entries}
+              displayOrder={[2, 1, 3]}
+            />
+
+            {/* 금전운 상세랭킹 */}
+            <FortuneDetailRankingSection
+              sectionTitle="금전운 상세랭킹"
+              rows={detailRows}
+              buttonText="멤버 추가하기"
+              onButtonClick={() => {
+                const target = groupId
+                  ? `/worth-test/question/1?type=member&groupId=${groupId}`
+                  : '/worth-test/question/1?type=member';
+                router.push(target);
+              }}
+            />
+            <div style={{ height: '100px' }} />
+          </>
+        )}
       </div>
 
       {/* 하단 고정 CTA 버튼 */}
@@ -562,5 +661,13 @@ export default function WorthTestGroupDetail() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function WorthTestGroupDetail() {
+  return (
+    <Suspense>
+      <WorthTestGroupDetailContent />
+    </Suspense>
   );
 }

--- a/src/app/worth-test/group/detail/page.tsx
+++ b/src/app/worth-test/group/detail/page.tsx
@@ -356,28 +356,33 @@ const MEMBER_LABELS: { label: string; ageGroup: WealthAgeGroup }[] = [
   { label: '80대', ageGroup: '80' },
 ];
 
-interface Top3Style {
-  barHeight: number;
-  barGradientStartColor?: string;
-  barGradientEndColor?: string;
-  barTextColor?: string;
+const BAR_HEIGHT_BY_RANK: Record<number, number> = {
+  1: 120,
+  2: 90,
+  3: 60,
+};
+
+interface Top3Colors {
+  barGradientStartColor: string;
+  barGradientEndColor: string;
+  barTextColor: string;
 }
 
-const TOP3_STYLE_BY_RANK: Record<number, Top3Style> = {
+const TOP3_COLORS_BY_RANK: Record<number, Top3Colors> = {
   1: {
-    barHeight: 120,
     barGradientStartColor: '#B5FFCA',
     barGradientEndColor: 'rgba(109, 153, 143, 0)',
     barTextColor: '#DBFFCE',
   },
   2: {
-    barHeight: 90,
     barGradientStartColor: '#C6B5FF',
     barGradientEndColor: 'rgba(198, 181, 255, 0)',
     barTextColor: '#C3D1F1',
   },
   3: {
-    barHeight: 60,
+    barGradientStartColor: '#72A5CA',
+    barGradientEndColor: 'rgba(114, 165, 202, 0)',
+    barTextColor: '#70B7E6',
   },
 };
 
@@ -398,12 +403,12 @@ function toTop3Entries(
 ): RankingEntry[] {
   return [1, 2, 3].map((rank) => {
     const entry = rankings.find((e) => e.rank === rank);
-    const style = TOP3_STYLE_BY_RANK[rank] ?? { barHeight: 60 };
+    const barHeight = BAR_HEIGHT_BY_RANK[rank] ?? 60;
     if (!entry) {
       return {
         rank,
+        barHeight,
         scoreIconSrc: '/icons/icon-flying-money.svg',
-        ...style,
       };
     }
     return {
@@ -411,7 +416,8 @@ function toTop3Entries(
       name: entry.name,
       score: formatAmount(entry.amount),
       scoreIconSrc: '/icons/icon-flying-money.svg',
-      ...style,
+      barHeight,
+      ...TOP3_COLORS_BY_RANK[rank],
     };
   });
 }

--- a/src/app/worth-test/group/detail/page.tsx
+++ b/src/app/worth-test/group/detail/page.tsx
@@ -415,6 +415,7 @@ function toTop3Entries(
       rank,
       name: entry.name,
       score: formatAmount(entry.amount),
+      imageUrl: entry.result.fortuneTypeImageUrl,
       scoreIconSrc: '/icons/icon-flying-money.svg',
       barHeight,
       ...TOP3_COLORS_BY_RANK[rank],

--- a/src/app/worth-test/page.tsx
+++ b/src/app/worth-test/page.tsx
@@ -15,6 +15,7 @@ import { shareRootUrl } from "@/utils/share";
 import { isNativeApp } from "@/utils/device";
 import { close } from "@/utils/bridge";
 import { postShareComplete } from "@/api/share";
+import { getWorthTestStats } from "@/api/worthTest";
 import { useScreenImpression, ScreenName } from "@/analytics";
 
 function HomeContent() {
@@ -23,6 +24,7 @@ function HomeContent() {
   const { resetAll } = useTestStore();
   const [isApp, setIsApp] = useState(false);
   const [showExitModal, setShowExitModal] = useState(false);
+  const [totalParticipants, setTotalParticipants] = useState<number | null>(null);
 
   useScreenImpression(ScreenName.HOME);
 
@@ -31,19 +33,15 @@ function HomeContent() {
   }, []);
 
   useEffect(() => {
+    getWorthTestStats()
+      .then((response) => setTotalParticipants(response.totalParticipants))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
     const token = searchParams.get('shareToken');
     if (token) {
-      postShareComplete(token)
-        .then((response) => {
-          if (process.env.NODE_ENV === 'development') {
-            console.log('[Home] ShareComplete API Success:', response);
-          }
-        })
-        .catch((error) => {
-          if (process.env.NODE_ENV === 'development') {
-            console.error('[Home] ShareComplete API Error:', error);
-          }
-        });
+      postShareComplete(token).catch(() => {});
     }
   }, [searchParams]);
 
@@ -133,7 +131,11 @@ function HomeContent() {
             />
             <div className="relative">
             <MoreBtn showIcon={false}>
-              지금까지 <span style={{ color: '#D8DCE2' }}>389</span>명이 참여했어요
+              지금까지{' '}
+              <span style={{ color: '#D8DCE2' }}>
+                {(totalParticipants ?? 389).toLocaleString()}
+              </span>
+              명이 참여했어요
             </MoreBtn>
             </div>
           </div>

--- a/src/app/worth-test/page.tsx
+++ b/src/app/worth-test/page.tsx
@@ -21,7 +21,7 @@ import { useScreenImpression, ScreenName } from "@/analytics";
 function HomeContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { resetAll } = useTestStore();
+  const { resetAll, setWorthResultId, setGroupNameInput } = useTestStore();
   const [isApp, setIsApp] = useState(false);
   const [showExitModal, setShowExitModal] = useState(false);
   const [totalParticipants, setTotalParticipants] = useState<number | null>(null);
@@ -163,7 +163,11 @@ function HomeContent() {
               status="active"
               size="xl"
               fullWidth
-              onClick={() => router.push('/worth-test/group/create')}
+              onClick={() => {
+                setWorthResultId(null);
+                setGroupNameInput('');
+                router.push('/worth-test/group/create');
+              }}
             >
               랭킹 그룹 만들기
             </CTAButton>

--- a/src/app/worth-test/question/2/page.tsx
+++ b/src/app/worth-test/question/2/page.tsx
@@ -14,18 +14,30 @@ import { validateDateField, formatBirthTime } from "@/utils/dateValidation";
 import { QuestionBanner } from "../_components/QuestionBanner";
 import { QUESTION_2_COPY, parseQuestionType } from "../_types/questionType";
 import { useScreenImpression, ScreenName } from "@/analytics";
+import {
+  mapStoreToWealthRequest,
+  postWorthGroupJoin,
+  postWorthTest,
+} from "@/api/worthTest";
 
 function Question2Content() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const questionType = parseQuestionType(searchParams.get("type"));
   const copy = QUESTION_2_COPY[questionType];
-  const { userBirth, setUserBirth } = useTestStore();
+  const {
+    userInfo,
+    userBirth,
+    setUserBirth,
+    setWorthResultId,
+    worthGroup,
+  } = useTestStore();
   const yearRef = useRef<HTMLInputElement>(null);
   const monthRef = useRef<HTMLInputElement>(null);
   const dayRef = useRef<HTMLInputElement>(null);
   const timeRef = useRef<HTMLInputElement>(null);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
 
   useScreenImpression(ScreenName.QUESTION_2);
 
@@ -47,9 +59,26 @@ function Question2Content() {
 
   const isFormValid = userBirth.year && userBirth.month && userBirth.day && (userBirth.unknownTime || userBirth.birthTime);
 
-  const handleNext = () => {
-    if (isFormValid) {
+  const handleNext = async () => {
+    if (!isFormValid || submitting) return;
+    setSubmitting(true);
+    try {
+      const request = mapStoreToWealthRequest({ userInfo, userBirth });
+      const response = await postWorthTest(request);
+      setWorthResultId(response.resultId);
+
+      if (questionType === 'member' && worthGroup?.groupId) {
+        await postWorthGroupJoin(worthGroup.groupId, {
+          resultId: response.resultId,
+        });
+        router.push(`/worth-test/group/detail?groupId=${worthGroup.groupId}`);
+        return;
+      }
+
       router.push("/worth-test/result");
+    } catch {
+      alert('결과 처리 중 오류가 발생했어요. 잠시 후 다시 시도해주세요.');
+      setSubmitting(false);
     }
   };
 
@@ -179,8 +208,8 @@ function Question2Content() {
         <div className="max-w-md w-full mx-auto">
           <CTAButtonGroup
             type="oneButton"
-            primaryButtonText="결과 확인"
-            primaryDisabled={!isFormValid}
+            primaryButtonText={submitting ? "처리 중..." : "결과 확인"}
+            primaryDisabled={!isFormValid || submitting}
             onPrimaryClick={handleNext}
           />
         </div>

--- a/src/app/worth-test/result/page.tsx
+++ b/src/app/worth-test/result/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { Suspense, useEffect, useMemo, useState } from "react";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { CTAButtonGroup } from "@/design-system/components/CTAButtonGroup";
 import { ScoreText } from "@/design-system/components/ScoreText/ScoreText";
 import { Title } from "@/design-system/components/Title";
@@ -12,24 +13,43 @@ import { colors, gradients } from "@/design-system/foundations/colors";
 import { openStore } from "@/utils/storeUrl";
 import { shareRootUrl } from "@/utils/share";
 import { typography } from "@/design-system/foundations/typography";
+import { useTestStore } from "@/store/useTestStore";
+import {
+  getWorthTestResult,
+  WealthFortuneEvent,
+  WealthFortuneResultResponse,
+  WealthTestResultResponse,
+} from "@/api/worthTest";
+
+function formatAmount(amount: number): string {
+  if (amount >= 100000000) {
+    const uk = Math.round(amount / 100000000);
+    return `${uk.toLocaleString()}억원`;
+  }
+  if (amount >= 10000) {
+    const man = Math.round(amount / 10000);
+    return `${man.toLocaleString()}만원`;
+  }
+  return `${amount.toLocaleString()}원`;
+}
 
 /** 점수/타입 결과 섹션 */
-function ScoreSection() {
+function ScoreSection({ result }: { result: WealthFortuneResultResponse }) {
   return (
     <>
       <div style={{ paddingTop: "26px" }}>
         <ScoreText
           type="result"
           badgeText="내 금전운 타입"
-          title="대기만성 거북이형"
-          description={"처음엔 느리지만 꾸준함이 힘이에요!\n무리하지 말고 차근차근 나아가는 힘이 있어요"}
+          title={result.fortuneType}
+          description={result.fortuneTypeDescription}
         />
       </div>
 
       <div className="max-w-md w-full" style={{ marginTop: "24px" }}>
         <img
-          src="https://picsum.photos/400/200"
-          alt="result"
+          src={result.fortuneTypeImageUrl}
+          alt={result.fortuneType}
           style={{ width: "100%", height: "200px", objectFit: "cover" }}
         />
       </div>
@@ -50,7 +70,7 @@ function ScoreSection() {
 }
 
 /** 금전운 상세보기 섹션 */
-function FortuneDetailSection() {
+function FortuneDetailSection({ fortuneDetail }: { fortuneDetail: string }) {
   return (
     <div
       className="max-w-md w-full"
@@ -73,16 +93,43 @@ function FortuneDetailSection() {
       >
         금전운 상세보기
       </h2>
-      <MessageCard
-        title="금전운"
-        message={"초년 고생, 말년 풍요: 젊을 때는 금전적 어려움이나 정체기가 있을 수 있으나, 꾸준한 노력으로 내공을 쌓아 크게 성공합니다.\n\n투자 및 인내: 당장의 작은 이익에 연연하지 않고 장기적인 관점에서 노력과 투자를 지속할 때 큰 결실을 봅니다.\n\n노력의 산물: 요행을 바라기보다는 묵묵히 자신의 분야에서 역량을 기르면, 그 대가가 뒤늦게 재물로 돌아오는 구조입니다."}
-      />
+      <MessageCard title="금전운" message={fortuneDetail} />
     </div>
   );
 }
 
 /** 금전운 인생 그래프 섹션 */
-function LifeGraphSection() {
+function LifeGraphSection({
+  result,
+}: {
+  result: WealthFortuneResultResponse;
+}) {
+  const dataPoints = useMemo(
+    () => result.graphData.map((p) => ({ x: p.age, value: p.amount })),
+    [result.graphData],
+  );
+
+  const events = useMemo(
+    () =>
+      result.events.map((e) => ({
+        x: e.age,
+        iconSrc: e.iconUrl,
+      })),
+    [result.events],
+  );
+
+  const peakPoint = useMemo(() => {
+    if (dataPoints.length === 0) {
+      return { x: 0, value: 0 };
+    }
+    return dataPoints.reduce(
+      (max, curr) => (curr.value > max.value ? curr : max),
+      dataPoints[0],
+    );
+  }, [dataPoints]);
+
+  const firstEvent: WealthFortuneEvent | undefined = result.events[0];
+
   return (
     <>
       <h2
@@ -101,69 +148,68 @@ function LifeGraphSection() {
         className="max-w-md w-full"
         style={{ marginTop: '16px' }}
         headerLabel="내 금전운 전성기"
-        dataPoints={[
-          { x: 20, value: 500 },
-          { x: 23, value: 800 },
-          { x: 35, value: 1500 },
-          { x: 47, value: 4500 },
-          { x: 60, value: 4528 },
-          { x: 75, value: 4300 },
-          { x: 80, value: 4100 },
-        ]}
+        dataPoints={dataPoints}
         peak={{
-          defaultX: 47,
-          ageLabel: "47살",
-          amountLabel: "4500만원",
+          defaultX: peakPoint.x,
+          ageLabel: `${peakPoint.x}살`,
+          amountLabel: formatAmount(peakPoint.value),
         }}
-        events={[
-          { x: 23, iconSrc: "/icons/icon-luckybag.svg" },
-          { x: 60, iconSrc: "/icons/icon-flying-money.svg" },
-        ]}
+        events={events}
         xAxisLabels={[20, 40, 60, 80]}
         xAxisLabelFormat={(x) => `${x}대`}
-        peakTooltipFormat={(v) => `${v.toLocaleString()}만원`}
+        peakTooltipFormat={(v) => formatAmount(v)}
       />
 
-      <div
-        className="max-w-md w-full"
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: '12px',
-          padding: '20px 24px',
-          backgroundColor: colors.neutral[700],
-          borderRadius: '12px',
-          margin: '16px 20px',
-        }}
-      >
+      {firstEvent && (
         <div
+          className="max-w-md w-full"
           style={{
-            width: '40px',
-            height: '40px',
-            borderRadius: '12px',
-            backgroundColor: '#2E3341',
             display: 'flex',
+            flexDirection: 'row',
             alignItems: 'center',
-            justifyContent: 'center',
-            flexShrink: 0,
+            gap: '12px',
+            padding: '20px 24px',
+            backgroundColor: colors.neutral[700],
+            borderRadius: '12px',
+            margin: '16px 20px',
           }}
         >
-          <Image src="/icons/icon-luckybag.svg" alt="" width={24} height={24} />
+          <div
+            style={{
+              width: '40px',
+              height: '40px',
+              borderRadius: '12px',
+              backgroundColor: '#2E3341',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            <img
+              src={firstEvent.iconUrl}
+              alt=""
+              width={24}
+              height={24}
+              style={{ display: 'block' }}
+            />
+          </div>
+          <span
+            style={{
+              fontFamily: 'Wanted Sans',
+              fontSize: '14px',
+              lineHeight: '20px',
+              fontWeight: 600,
+              color: colors.neutral[100],
+              whiteSpace: 'pre-line',
+            }}
+          >
+            {`${firstEvent.age}살에 ${firstEvent.description}\n${formatAmount(
+              Math.abs(firstEvent.amount),
+            )}${firstEvent.amount >= 0 ? '을 받아요' : '을 잃어요'}`}
+          </span>
         </div>
-        <span
-          style={{
-            fontFamily: 'Wanted Sans',
-            fontSize: '14px',
-            lineHeight: '20px',
-            fontWeight: 600,
-            color: colors.neutral[100],
-            whiteSpace: 'pre-line',
-          }}
-        >
-          23살에 로또에 2등에 당첨되서{'\n'}5,300만원을 받아요
-        </span>
-      </div>
+      )}
     </>
   );
 }
@@ -371,8 +417,32 @@ function CTASection({ onRestart }: { onRestart: () => void }) {
   );
 }
 
-export default function WorthTestResult() {
+function WorthTestResultContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { worthResultId } = useTestStore();
+  const resolvedResultId = searchParams.get('resultId') ?? worthResultId;
+
+  const [data, setData] = useState<WealthTestResultResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!resolvedResultId) {
+      setError('결과 ID가 없어요. 테스트를 먼저 진행해주세요.');
+      return;
+    }
+    let cancelled = false;
+    getWorthTestResult(resolvedResultId)
+      .then((response) => {
+        if (!cancelled) setData(response);
+      })
+      .catch(() => {
+        if (!cancelled) setError('결과를 불러오지 못했어요.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [resolvedResultId]);
 
   const handleShareConfirm = async () => {
     const result = await shareRootUrl();
@@ -381,19 +451,49 @@ export default function WorthTestResult() {
     }
   };
 
+  if (error) {
+    return (
+      <div
+        style={{ backgroundColor: colors.background.main, minHeight: '100vh', color: colors.text.main }}
+        className="flex items-center justify-center px-6 text-center"
+      >
+        {error}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div
+        style={{ backgroundColor: colors.background.main, minHeight: '100vh', color: colors.text.main }}
+        className="flex items-center justify-center"
+      >
+        결과 불러오는 중...
+      </div>
+    );
+  }
+
   return (
     <div
       style={{ backgroundColor: colors.background.main, minHeight: "100vh" }}
       className="flex flex-col items-center"
     >
-      <ScoreSection />
+      <ScoreSection result={data.result} />
       <div style={{ height: "24px" }} />
-      <FortuneDetailSection />
-      <LifeGraphSection />
+      <FortuneDetailSection fortuneDetail={data.result.fortuneDetail} />
+      <LifeGraphSection result={data.result} />
       <RankingSection onGroupCreate={() => router.push("/worth-test/group/create")} />
       <TipSection onShare={handleShareConfirm} />
       <PromotionSection />
       <CTASection onRestart={() => router.push("/worth-test")} />
     </div>
+  );
+}
+
+export default function WorthTestResult() {
+  return (
+    <Suspense>
+      <WorthTestResultContent />
+    </Suspense>
   );
 }

--- a/src/store/useTestStore.ts
+++ b/src/store/useTestStore.ts
@@ -43,6 +43,13 @@ interface LoveDate {
   day: string;
 }
 
+// worth-test 그룹 정보
+interface WorthGroup {
+  groupId: string;
+  groupName: string;
+  inviteCode: string;
+}
+
 interface TestState {
   // Q1 데이터
   userInfo: UserInfo;
@@ -67,6 +74,18 @@ interface TestState {
   // 공유 여부
   hasShared: boolean;
   setHasShared: (shared: boolean) => void;
+
+  // worth-test 결과 ID
+  worthResultId: string | null;
+  setWorthResultId: (resultId: string | null) => void;
+
+  // worth-test 그룹
+  worthGroup: WorthGroup | null;
+  setWorthGroup: (group: WorthGroup | null) => void;
+
+  // worth-test 그룹 이름 입력값
+  groupNameInput: string;
+  setGroupNameInput: (name: string) => void;
 
   // 전체 초기화
   resetAll: () => void;
@@ -106,6 +125,9 @@ const initialState = {
     day: '',
   },
   hasShared: false,
+  worthResultId: null,
+  worthGroup: null,
+  groupNameInput: '',
 };
 
 export const useTestStore = create<TestState>()(
@@ -139,6 +161,12 @@ export const useTestStore = create<TestState>()(
         })),
 
       setHasShared: (shared) => set({ hasShared: shared }),
+
+      setWorthResultId: (resultId) => set({ worthResultId: resultId }),
+
+      setWorthGroup: (group) => set({ worthGroup: group }),
+
+      setGroupNameInput: (name) => set({ groupNameInput: name }),
 
       resetAll: () => set(initialState),
     }),


### PR DESCRIPTION
  ## 배경                                                                                                                                                                                                      
                                                                                                                                                                                                               
  백엔드에 `https://dhc-2.duckdns.org/swagger` 기준 7개의 `/api/wealth-test/*` 엔드포인트가 신설됨. 기존 worth-test 페이지들은 모두 하드코딩된 mock 데이터로 동작 중이었던 걸 실제 API 기반으로 전환.          
                                                                                                                                                                                                               
  ## 변경 사항                                                                                                                                                                                                 
                                                                                                                                                                                                               
  ### 1. API 모듈 추가 — `src/api/worthTest/`              
  Swagger 스키마 1:1 매핑하여 타입 정의 + `apiClient` 래핑. 7개 엔드포인트 모두 함수 제공:
                                                                                                                                                                                                               
  | 함수 | 메서드 | 경로 |                                             
  |---|---|---|                                                                                                                                                                                                
  | `postWorthTest` | POST | `/api/wealth-test` |        
  | `getWorthTestResult` | GET | `/api/wealth-test/results/{resultId}` |                                                                                                                                       
  | `getWorthTestStats` | GET | `/api/wealth-test/stats` |                                                                                                                                                     
  | `postWorthGroup` | POST | `/api/wealth-test/groups` |                                                                                                                                                      
  | `getWorthGroupByInviteCode` | GET | `/api/wealth-test/groups/invite/{inviteCode}` |                                                                                                                        
  | `postWorthGroupJoin` | POST | `/api/wealth-test/groups/{groupId}/join` |                                                                                                                                   
  | `getWorthGroupRanking` | GET | `/api/wealth-test/groups/{groupId}/ranking` |                                                                                                                               
                                                                                                                                                                                                               
  ### 2. 페이지 통합                                                   
                                                                                                                                                                                                               
  - **홈** (`/worth-test`) — `getWorthTestStats` 로 누적 참여자 수 동적 표시 (기존 `389` 하드코딩 제거)                                                                                                        
  - **Question2** — `결과 확인` 클릭 시 `postWorthTest` 호출, `resultId` store 저장. `type=member` 진입 시 `postWorthGroupJoin` 까지 이어 실행
  - **Result** — `getWorthTestResult` 로 mock 치환: fortuneType / fortuneDetail / graphData / events 모두 API 응답 기반                                                                                        
  - **GroupCreate** — `postWorthGroup` 호출, `userInfo.name` 오용을 `groupNameInput` 전용 필드로 분리                                                                                                          
  - **GroupDetail** — `?groupId` 쿼리 기반 `getWorthGroupRanking` 호출, ageGroup 탭 전환 시 재조회, 랭킹/TOP3 포디움 동적 렌더                                                                                 
                                                                                                                                                                                                               
  ### 3. Store 확장 — `useTestStore`                                                                                                                                                                           
                                                                                                                                                                                                               
  - `worthResultId`, `worthGroup`, `groupNameInput` 필드 + setter 추가 (`resetAll` 에 포함)                                                                                                                    
                                                                       
  ### 4. 인프라 · 품질                                                                                                                                                                                         
                                                                       
  - `next.config.ts` — Oracle Object Storage 이미지 호스트(`objectstorage.ap-chuncheon-1.oraclecloud.com`) 허용. wealth-test 결과의 `fortuneTypeImageUrl` 및 event `iconUrl` 이 여기에 의존                    
  - `apiClient` — dev 모드 전용 요청/응답/실패 로깅 한 곳에서 일원화   
  - 각 페이지의 중복 `console.error` 제거 (worth-test / love-test)                                                                                                                                             
                                                                                                                                                                                                               
  ### 5. UX 버그 픽스                                                                                                                                                                                          
                                                                                                                                                                                                               
  - 메인 → `랭킹 그룹 만들기` 진입 시 persist 된 `worthResultId` 가 `postWorthGroup` 에 끼워 들어가 이전 테스트 결과가 첫 멤버로 등록되던 문제 수정 → 빈 그룹으로 생성되도록 초기화                            
  - 랭킹 포디움 3등에 색상(`#72A5CA` → transparent, 텍스트 `#70B7E6`) 지정. 동시에 1·2·3등 모두 **해당 rank 데이터가 실제로 있을 때만** 색을 적용, 없으면 디자인 시스템의 점선 placeholder 로 렌더
  - 포디움 아바타를 상세랭킹 행과 동일하게 `entry.result.fortuneTypeImageUrl` 로 렌더 (기존 `?` placeholder)                                                                                                   
                                                                                                                                                                                                               
  ## 이번 PR 범위 밖                                                                                                                                                                                           
                                                                                                                                                                                                               
  - **초대 링크 전용 페이지** (`/worth-test/group/invite/[inviteCode]`) — 디자인/플로우 미정                                                                                                                   
    - `getWorthGroupByInviteCode` 함수는 모듈에 생성되어 있으나 호출 페이지 없음
    - `postWorthGroupJoin` 은 "멤버 추가하기" 내부 플로우에만 연결됨. 외부인이 초대 링크로 가입하는 경로는 페이지 생성 후 연결 필요     