### PR TITLE
fix: iOS Safari input 포커스 시 자동 확대 방지

### DIFF
--- a/src/design-system/components/InputField/InputField.tsx
+++ b/src/design-system/components/InputField/InputField.tsx
@@ -102,6 +102,7 @@ export const InputField: React.FC<InputFieldProps> = ({
       borderRadius: '8px',
       backgroundColor: colors.neutral[700],
       ...typography.title.h6,
+      fontSize: '16px',
       textAlign: 'center',
       transition: 'all 0.2s ease',
       outline: 'none',


### PR DESCRIPTION
InputField의 input font-size가 15px(typography.title.h6)이라 iOS Safari가 포커스 시 페이지를 자동 확대하는 이슈가 있어 16px로 override.
디자인 토큰은 유지하고 input 한정으로 적용.